### PR TITLE
Add qrUrl field to response

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.21.5
 
     environment:
       TEST_RESULTS: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: cimg/go:1.21.5
+      - image: cimg/go:1.18
 
     environment:
       TEST_RESULTS: /tmp/test-results

--- a/pkg/models/response_doc.go
+++ b/pkg/models/response_doc.go
@@ -19,6 +19,7 @@ type Response struct {
 	ClassificationMark *uint64 `xml:"classificationMark"`
 	AuthenticationCode *string `xml:"authenticationCode"`
 	CancellationMark   *uint64 `xml:"cancellationMark"`
+	QRCodeURL          *string `xml:"qrUrl"`
 }
 
 type Error struct {


### PR DESCRIPTION
New in v1.0.7:

Κατά τη διαβίβαση παραστατικού από ERP επιστρέφεται επιπλέον κωδικοποιημένο κείμενο το οποίο χρησιμοποιείται προκειμένου να δημιουργηθεί QR code (τύπου URL), για την επισκόπηση του παραστατικού.

![image](https://github.com/ppapapetrou76/go-mydata-aade/assets/22637722/506241ff-ea0e-4716-9697-12330f5cf4cd)